### PR TITLE
Refactor Tabs to replace prop-drilling with store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "react-router-dom": "^6.4.1",
         "react-scripts": "5.0.1",
         "typescript": "^4.8.3",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "zustand": "^4.3.6"
       },
       "devDependencies": {
         "gh-pages": "^4.0.0"
@@ -15801,6 +15802,14 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -16779,6 +16788,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.6.tgz",
+      "integrity": "sha512-6J5zDxjxLE+yukC2XZWf/IyWVKnXT9b9HUv09VJ/bwGCpKNcaTqp7Ws28Xr8jnbvnZcdRaidztAPsXFBIqufiw==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   },
@@ -27908,6 +27940,12 @@
         "requires-port": "^1.0.0"
       }
     },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -28671,6 +28709,14 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zustand": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.6.tgz",
+      "integrity": "sha512-6J5zDxjxLE+yukC2XZWf/IyWVKnXT9b9HUv09VJ/bwGCpKNcaTqp7Ws28Xr8jnbvnZcdRaidztAPsXFBIqufiw==",
+      "requires": {
+        "use-sync-external-store": "1.2.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-router-dom": "^6.4.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.8.3",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "zustand": "^4.3.6"
   },
   "scripts": {
     "predeploy": "npm run build",

--- a/src/components/TabContent.tsx
+++ b/src/components/TabContent.tsx
@@ -3,35 +3,31 @@ import "../css/TabContent.css";
 import AboutMe from "./AboutMe";
 import Contact from "./Contact";
 import Projects from "./Projects";
+import { useTabStore, TabState } from "../data/Store";
 
-export interface PropTypes {
-  loading: boolean;
-  error: false;
-  activeTab: string;
-  setActiveTab: Dispatch<string>;
-}
+export default function TabContent() {
+	const activeTab = useTabStore((state: TabState) => state.activeTab);
+	const [firstRender, setFirstRender] = useState(true);
 
-export default function TabContent(props: PropTypes) {
-  const [firstRender, setFirstRender] = useState(true);
-  useEffect(() => {
-    setTimeout(() => {
-      setFirstRender((prev) => false);
-      const homeContainer = document.getElementById("home-container");
-      if (homeContainer) {
-        homeContainer.style.overflow = "visible";
-      }
-    }, 2500);
-  }, []);
+	useEffect(() => {
+		setTimeout(() => {
+			setFirstRender((prev) => false);
+			const homeContainer = document.getElementById("home-container");
+			if (homeContainer) {
+				homeContainer.style.overflow = "visible";
+			}
+		}, 2500);
+	}, []);
 
-  return (
-    <div className="content-container" id="content-container">
-      {props.activeTab === "About Me" ? (
-        <AboutMe firstRender={firstRender} />
-      ) : props.activeTab === "Projects" ? (
-        <Projects />
-      ) : (
-        <Contact />
-      )}
-    </div>
-  );
+	return (
+		<div className="content-container" id="content-container">
+			{activeTab === "About Me" ? (
+				<AboutMe firstRender={firstRender} />
+			) : activeTab === "Projects" ? (
+				<Projects />
+			) : (
+				<Contact />
+			)}
+		</div>
+	);
 }

--- a/src/components/TabHeaders.tsx
+++ b/src/components/TabHeaders.tsx
@@ -1,15 +1,14 @@
-import React, { SetStateAction } from "react";
 import "../css/Tabs.css";
 import kkminlogo_light from "../assets/kkminlogo_light.png";
-import { useTabStore } from "../data/Store";
+import { useTabStore, TabState } from "../data/Store";
 
 export interface PropTypes {
 	tabNames: string[];
 }
 
 export default function TabHeaders(props: PropTypes) {
-	const activeTab = useTabStore((state: any) => state.activeTab);
-	const setActiveTab = useTabStore((state: any) => state.setActiveTab);
+	const activeTab = useTabStore((state: TabState) => state.activeTab);
+	const setActiveTab = useTabStore((state: TabState) => state.setActiveTab);
 	// onClick function for when a tab is clicked:
 	const tabClickHandler = (tabname: string) => {
 		if (tabname === activeTab) {

--- a/src/components/TabHeaders.tsx
+++ b/src/components/TabHeaders.tsx
@@ -11,7 +11,7 @@ export default function TabHeaders(props: PropTypes) {
 	const activeTab = useTabStore((state: any) => state.activeTab);
 	const setActiveTab = useTabStore((state: any) => state.setActiveTab);
 	// onClick function for when a tab is clicked:
-	const tabClickHandler = (event: React.MouseEvent, tabname: string) => {
+	const tabClickHandler = (tabname: string) => {
 		if (tabname === activeTab) {
 			// Tab is already active
 			return;
@@ -33,7 +33,7 @@ export default function TabHeaders(props: PropTypes) {
 							? () => {
 								window.open("https://kkmin.vercel.app", "_blank");
 							}
-							: (event) => tabClickHandler(event, name)
+							: () => tabClickHandler(name)
 					}
 				>
 					{name}

--- a/src/components/TabHeaders.tsx
+++ b/src/components/TabHeaders.tsx
@@ -1,22 +1,23 @@
 import React, { SetStateAction } from "react";
 import "../css/Tabs.css";
 import kkminlogo_light from "../assets/kkminlogo_light.png";
+import { useTabStore } from "../data/Store";
 
 export interface PropTypes {
 	tabNames: string[];
-	activeTab: string;
-	setActiveTab: React.Dispatch<SetStateAction<string>>;
 }
 
 export default function TabHeaders(props: PropTypes) {
+	const activeTab = useTabStore((state: any) => state.activeTab);
+	const setActiveTab = useTabStore((state: any) => state.setActiveTab);
 	// onClick function for when a tab is clicked:
 	const tabClickHandler = (event: React.MouseEvent, tabname: string) => {
-		if (tabname === props.activeTab) {
+		if (tabname === activeTab) {
 			// Tab is already active
 			return;
 		}
 
-		props.setActiveTab(tabname);
+		setActiveTab(tabname);
 		window.scroll(0, 0);
 	};
 
@@ -26,7 +27,7 @@ export default function TabHeaders(props: PropTypes) {
 				<button
 					id={name}
 					key={name}
-					className={name === props.activeTab ? "tabheaderactive" : "tabheader"}
+					className={name === activeTab ? "tabheaderactive" : "tabheader"}
 					onClick={
 						name === "Blog"
 							? () => {

--- a/src/components/TabHeaders.tsx
+++ b/src/components/TabHeaders.tsx
@@ -3,44 +3,44 @@ import "../css/Tabs.css";
 import kkminlogo_light from "../assets/kkminlogo_light.png";
 
 export interface PropTypes {
-  tabNames: string[];
-  activeTab: string;
-  setActiveTab: React.Dispatch<SetStateAction<string>>;
+	tabNames: string[];
+	activeTab: string;
+	setActiveTab: React.Dispatch<SetStateAction<string>>;
 }
 
 export default function TabHeaders(props: PropTypes) {
-  // onClick function for when a tab is clicked:
-  const tabClickHandler = (event: React.MouseEvent, tabname: string) => {
-    if (tabname === props.activeTab) {
-      // Tab is already active
-      return;
-    }
+	// onClick function for when a tab is clicked:
+	const tabClickHandler = (event: React.MouseEvent, tabname: string) => {
+		if (tabname === props.activeTab) {
+			// Tab is already active
+			return;
+		}
 
-    props.setActiveTab((prev) => tabname);
-    window.scroll(0, 0);
-  };
+		props.setActiveTab(tabname);
+		window.scroll(0, 0);
+	};
 
-  return (
-    <div className="tabs" id="tabs">
-      {props.tabNames.map((name) => (
-        <button
-          id={name}
-          key={name}
-          className={name === props.activeTab ? "tabheaderactive" : "tabheader"}
-          onClick={
-            name === "Blog"
-              ? () => {
-                  window.open("https://kkmin.vercel.app", "_blank");
-                }
-              : (event) => tabClickHandler(event, name)
-          }
-        >
-          {name}
-        </button>
-      ))}
-      <div className="tabsfiller">
-        <img className="tabslogo" src={kkminlogo_light} alt="KK Min" />
-      </div>
-    </div>
-  );
+	return (
+		<div className="tabs" id="tabs">
+			{props.tabNames.map((name) => (
+				<button
+					id={name}
+					key={name}
+					className={name === props.activeTab ? "tabheaderactive" : "tabheader"}
+					onClick={
+						name === "Blog"
+							? () => {
+								window.open("https://kkmin.vercel.app", "_blank");
+							}
+							: (event) => tabClickHandler(event, name)
+					}
+				>
+					{name}
+				</button>
+			))}
+			<div className="tabsfiller">
+				<img className="tabslogo" src={kkminlogo_light} alt="KK Min" />
+			</div>
+		</div>
+	);
 }

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -6,20 +6,12 @@ import { useTabStore } from '../data/Store';
 const tab_names = ['About Me', 'Projects', 'Contact', 'Blog'];
 
 export default function Tabs() {
-	const activeTab = useTabStore((state: any) => state.activeTab);
-	const setActiveTab = useTabStore((state: any) => state.setActiveTab);
-
 	return (
 		<div className='tabs-container'>
 			<TabHeaders
 				tabNames={tab_names.map((site_name) => site_name)}
 			/>
-			<TabContent
-				loading={false}
-				error={false}
-				activeTab={activeTab}
-				setActiveTab={setActiveTab}
-			/>
+			<TabContent />
 		</div>
 	);
 }

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import TabContent from './TabContent';
 import TabHeaders from './TabHeaders';
+import { useTabStore } from '../data/Store';
 
 const tab_names = ['About Me', 'Projects', 'Contact', 'Blog'];
 
 export default function Tabs() {
-	const [activeTab, setActiveTab] = useState(tab_names[0]);
+	const activeTab = useTabStore((state: any) => state.activeTab);
+	const setActiveTab = useTabStore((state: any) => state.setActiveTab);
 
 	return (
 		<div className='tabs-container'>

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -13,8 +13,6 @@ export default function Tabs() {
 		<div className='tabs-container'>
 			<TabHeaders
 				tabNames={tab_names.map((site_name) => site_name)}
-				activeTab={activeTab}
-				setActiveTab={setActiveTab}
 			/>
 			<TabContent
 				loading={false}

--- a/src/data/Store.tsx
+++ b/src/data/Store.tsx
@@ -1,6 +1,11 @@
 import { create } from 'zustand'
 
-export const useTabStore = create((set) => ({
+export interface TabState {
+	activeTab: string
+	setActiveTab: (tab: string) => void
+}
+
+export const useTabStore = create<TabState>((set) => ({
 	activeTab: "About Me",
 	setActiveTab: (tab: string) => set({ activeTab: tab }),
 }))

--- a/src/data/Store.tsx
+++ b/src/data/Store.tsx
@@ -1,0 +1,6 @@
+import { create } from 'zustand'
+
+export const useTabStore = create((set) => ({
+	activeTab: "About Me",
+	setActiveTab: (tab: string) => set({ activeTab: tab }),
+}))


### PR DESCRIPTION
This PR refactors components related to the Tab functionality to prevent prop-drilling by replacing it with a state management library.

## Changes
- Refactor Tabs.tsx, TabHeaders.tsx, TabContent.tsx to remove activeTab/setActiveTab state and setState function
- Add Store.tsx for storage of shared values such as activeTab using [zustand](https://github.com/pmndrs/zustand)