### PR TITLE
Refactor lock puzzle to replace prop-drilling store

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -16,6 +16,12 @@ export default function Contact() {
 	const setFirstRender = usePuzzleStore((state) => state.setFirstRender);
 
 	useEffect(() => {
+		document.addEventListener('animationend', function(e: any) {
+			if (e && e.animationName == 'fade-out') {
+				e.target.style.display = 'none';
+			}
+		});
+
 		if (isAnimating) {
 			setTimeout(() => {
 				setIsAnimating(false);

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -3,175 +3,109 @@ import Lock from './Lock';
 import ProjectItem from './ProjectItem';
 import Unlocker from './Unlocker';
 import reset_arrow from '../assets/reset_arrow.png';
+import { usePuzzleStore } from '../data/Store'
 
-const randomizerArray = ['1', '2', '3', '4'];
-
-const getRandomSecret = (sourceArray: string[]) => {
-    let secret: string = '';
-    let tempArray = [...sourceArray];
-    while (tempArray.length > 0) {
-        let index = Math.floor(Math.random() * tempArray.length);
-        let randomItem = tempArray[index];
-        secret += randomItem;
-        tempArray.splice(index, 1); // Remove selected item from array
-    }
-    return secret;
-};
 
 export default function Contact() {
-    const [secret, setSecret] = useState(getRandomSecret(randomizerArray));
-    const [input, setInput] = useState('');
-    const [lockState, setLockState] = useState('default');
-    const [isAnimating, setIsAnimating] = useState(true);
+	const lockStatus = usePuzzleStore((state) => state.lockStatus);
+	const isAnimating = usePuzzleStore((state) => state.isAnimating);
+	const resetSecret = usePuzzleStore((state) => state.resetSecret);
+	const setLockStatus = usePuzzleStore((state) => state.setLockStatus);
+	const setInput = usePuzzleStore((state) => state.setInput);
+	const setIsAnimating = usePuzzleStore((state) => state.setIsAnimating);
 
-    useEffect(() => {
-        const lockElement = document.getElementById('lock');
-        const unlockerElement = document.getElementById('unlocker');
-        const contactElement = document.getElementById('contact-card');
+	useEffect(() => {
+		const lockElement = document.getElementById('lock');
+		const unlockerElement = document.getElementById('unlocker');
+		const contactElement = document.getElementById('contact-card');
 
-        if (lockState === 'open') {
-            setTimeout(() => {
-                if (lockElement) {
-                    lockElement.style.display = 'none';
-                }
-                if (unlockerElement) {
-                    unlockerElement.style.display = 'none';
-                }
-                if (contactElement) {
-                    contactElement.className = 'contact-info';
-                }
-            }, 2000);
-            return;
-        } else {
-            setTimeout(() => {
-                setIsAnimating(false);
-            }, 5000);
-        }
-    }, [lockState]);
+		if (lockStatus === 'open') {
+			setTimeout(() => {
+				if (lockElement) {
+					lockElement.style.display = 'none';
+				}
+				if (unlockerElement) {
+					unlockerElement.style.display = 'none';
+				}
+				if (contactElement) {
+					contactElement.className = 'contact-info';
+				}
+			}, 2000);
+			return;
+		} else {
+			setTimeout(() => {
+				setIsAnimating(false);
+			}, 5000);
+		}
+	}, [lockStatus]);
 
-    useEffect(() => {
-        if (lockState === 'open') {
-            return;
-        }
+	const resetHandler = () => {
+		if (isAnimating) {
+			return;
+		}
 
-        const resetElement = document.getElementById('reset-button');
-        if (!isAnimating) {
-            if (resetElement) {
-                resetElement.className = 'reset-button enabled';
-            }
-        }
-    }, [isAnimating, lockState]);
+		// Clear all setTimeOut functions:
+		var timeOutID = window.setTimeout(function() { }, 0);
+		while (timeOutID--) {
+			window.clearTimeout(timeOutID);
+		}
+		resetSecret()
+		setInput('');
+		setLockStatus('default');
+		setIsAnimating(true);
 
-    const addInput = (input: string) => {
-        setInput((prev) => prev + input);
-    };
+		setTimeout(() => {
+			setIsAnimating(false);
+		}, 5000);
+	}
 
-    const resetHandler = () => {
-        if (isAnimating) {
-            return;
-        }
-
-        // Clear all setTimeOut functions:
-        var timeOutID = window.setTimeout(function () {}, 0);
-        while (timeOutID--) {
-            window.clearTimeout(timeOutID);
-        }
-
-        const resetElement = document.getElementById('reset-button');
-        if (resetElement) {
-            if (resetElement.className === 'reset-button disabled') {
-                return;
-            }
-
-            resetElement.classList.add('rotate');
-            resetElement.classList.remove('enabled');
-            resetElement.classList.add('disabled');
-
-            const lockContainerElement = document.getElementById('lock');
-            const lockImageElement = document.getElementById('lock-image');
-            const unlockerElement = document.getElementById('unlocker');
-            if (lockContainerElement) {
-                lockContainerElement.style.removeProperty('display');
-            }
-
-            if (unlockerElement) {
-                unlockerElement.style.removeProperty('display');
-            }
-
-            setSecret((prev) => getRandomSecret(randomizerArray));
-            setInput((prev) => '');
-            setLockState((prev) => 'default');
-            setIsAnimating((prev) => true);
-
-            if (lockImageElement) {
-                console.log('Resetting lock to initial');
-                lockImageElement.classList.add('initial');
-                setTimeout(() => {
-                    lockImageElement.className = 'lock';
-                }, 1000);
-            }
-        }
-        setTimeout(() => {
-            resetElement?.classList.remove('rotate');
-            resetElement?.classList.remove('disabled');
-            setIsAnimating((prev) => false);
-        }, 5000);
-    };
-
-    return (
-        <div className='content'>
-            <div className='title-container'>
-                <h1 className='tab-title'>Contact</h1>
-                <img
-                    id='reset-button'
-                    className='reset-button disabled'
-                    onClick={resetHandler}
-                    src={reset_arrow}
-                    alt='reset'
-                />
-            </div>
-            <Lock
-                secret={secret}
-                input={input}
-                lockState={lockState}
-                setLockState={setLockState}
-            />
-            <Unlocker
-                secret={secret}
-                addInput={addInput}
-                lockState={lockState}
-            />
-            {lockState === 'open' ? (
-                <div className='contact-info-invisible' id='contact-card'>
-                    <ProjectItem
-                        projectTitle='Min Kabar Kyaw'
-                        projectDescription=''
-                        projectIcon=''
-                        projectRole='Software Developer'
-                        projectLink=''
-                        projectBulletPoints={[
-                            'E' +
-                                'ma' +
-                                'il:' +
-                                ' ' +
-                                'mi' +
-                                'n' +
-                                'kab' +
-                                'a' +
-                                'r' +
-                                'ky' +
-                                'aw' +
-                                '(at)' +
-                                'g' +
-                                'mai' +
-                                'l' +
-                                '.c' +
-                                'om',
-                            'LinkedIn: https://www.linkedin.com/in/minkk/',
-                        ]}
-                    />
-                </div>
-            ) : null}
-        </div>
-    );
+	return (
+		<div className='content'>
+			<div className='title-container'>
+				<h1 className='tab-title'>Contact</h1>
+				<img
+					id='reset-button'
+					className={'reset-button' + (isAnimating ? ' disabled rotate' : ' enabled')}
+					onClick={resetHandler}
+					src={reset_arrow}
+					alt='reset'
+				/>
+			</div>
+			<Lock
+			/>
+			<Unlocker
+			/>
+			{lockStatus === 'open' ? (
+				<div className='contact-info-invisible' id='contact-card'>
+					<ProjectItem
+						projectTitle='Min Kabar Kyaw'
+						projectDescription=''
+						projectIcon=''
+						projectRole='Software Developer'
+						projectLink=''
+						projectBulletPoints={[
+							'E' +
+							'ma' +
+							'il:' +
+							' ' +
+							'mi' +
+							'n' +
+							'kab' +
+							'a' +
+							'r' +
+							'ky' +
+							'aw' +
+							'(at)' +
+							'g' +
+							'mai' +
+							'l' +
+							'.c' +
+							'om',
+							'LinkedIn: https://www.linkedin.com/in/minkk/',
+						]}
+					/>
+				</div>
+			) : null}
+		</div>
+	);
 }

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -13,26 +13,10 @@ export default function Contact() {
 	const setLockStatus = usePuzzleStore((state) => state.setLockStatus);
 	const setInput = usePuzzleStore((state) => state.setInput);
 	const setIsAnimating = usePuzzleStore((state) => state.setIsAnimating);
+	const setFirstRender = usePuzzleStore((state) => state.setFirstRender);
 
 	useEffect(() => {
-		const lockElement = document.getElementById('lock');
-		const unlockerElement = document.getElementById('unlocker');
-		const contactElement = document.getElementById('contact-card');
-
-		if (lockStatus === 'open') {
-			setTimeout(() => {
-				if (lockElement) {
-					lockElement.style.display = 'none';
-				}
-				if (unlockerElement) {
-					unlockerElement.style.display = 'none';
-				}
-				if (contactElement) {
-					contactElement.className = 'contact-info';
-				}
-			}, 2000);
-			return;
-		} else {
+		if (isAnimating) {
 			setTimeout(() => {
 				setIsAnimating(false);
 			}, 5000);
@@ -53,6 +37,7 @@ export default function Contact() {
 		setInput('');
 		setLockStatus('default');
 		setIsAnimating(true);
+		setFirstRender(true);
 
 		setTimeout(() => {
 			setIsAnimating(false);
@@ -76,7 +61,7 @@ export default function Contact() {
 			<Unlocker
 			/>
 			{lockStatus === 'open' ? (
-				<div className='contact-info-invisible' id='contact-card'>
+				<div className={lockStatus === 'open' ? 'contact-info' : 'contact-info-invisible'} id='contact-card'>
 					<ProjectItem
 						projectTitle='Min Kabar Kyaw'
 						projectDescription=''
@@ -105,7 +90,8 @@ export default function Contact() {
 						]}
 					/>
 				</div>
-			) : null}
-		</div>
+			) : null
+			}
+		</div >
 	);
 }

--- a/src/components/Lock.tsx
+++ b/src/components/Lock.tsx
@@ -2,16 +2,18 @@ import React, { useState, useEffect, useMemo } from 'react';
 import padlock_default from '../assets/padlock_default.png';
 import padlock_open from '../assets/padlock_open.png';
 import padlock_error from '../assets/padlock_error.png';
+import { usePuzzleStore } from '../data/Store';
 
-export interface PropTypes {
-	secret: string;
-	input: string;
-	lockState: string;
-	setLockState: React.Dispatch<React.SetStateAction<string>>;
-}
 
-export default function Lock(props: PropTypes) {
-	const [firstRender, setFirstRender] = useState(true);
+export default function Lock() {
+	const firstRender = usePuzzleStore((state) => state.firstRender)
+	const lockStatus = usePuzzleStore((state) => state.lockStatus)
+
+	if (firstRender) {
+		setTimeout(() => {
+			usePuzzleStore.setState({ firstRender: false })
+		}, 300)
+	}
 
 	const defaultLock = useMemo(() => {
 		return padlock_default;
@@ -25,32 +27,15 @@ export default function Lock(props: PropTypes) {
 		return padlock_error;
 	}, []);
 
-	useEffect(() => {
-		setTimeout(() => {
-			setFirstRender((prev) => false);
-		}, 1000);
-	}, []);
-
-	useEffect(() => {
-		setFirstRender((prev) => true);
-	}, [props.lockState]);
-
 	const onClickHandler = () => {
 		const lockElement = document.getElementById('lock-image');
 		if (lockElement) {
 			// Input not completely filled
-			if (props.input.length < props.secret.length) {
+			if (lockStatus === 'default') {
 				lockElement.classList.add('shaking');
 				setTimeout(() => {
 					lockElement.classList.remove('shaking');
 				}, 300);
-			} else if (props.input !== props.secret) {
-				// Input is incorrect
-				lockElement.className = 'lock-failed';
-				props.setLockState('error');
-			} else {
-				// Input completely filled and correct
-				props.setLockState('open');
 			}
 		}
 	};
@@ -59,7 +44,7 @@ export default function Lock(props: PropTypes) {
 		<div
 			id='lock'
 			className={
-				props.lockState === 'open'
+				lockStatus === 'open'
 					? 'lock-container-exit'
 					: 'lock-container'
 			}
@@ -68,20 +53,20 @@ export default function Lock(props: PropTypes) {
 				id='lock-image'
 				className={
 					'lock' +
-					(props.lockState === 'open'
+					(lockStatus === 'open'
 						? '-exit'
-						: props.lockState === 'error'
-						? '-failed'
-						: firstRender
-						? ' initial'
-						: '')
+						: lockStatus === 'error'
+							? '-failed'
+							: firstRender
+								? ' initial'
+								: '')
 				}
 				src={
-					props.lockState === 'default'
+					lockStatus === 'default'
 						? defaultLock
-						: props.lockState === 'open'
-						? openLock
-						: errorLock
+						: lockStatus === 'open'
+							? openLock
+							: errorLock
 				}
 				onClick={onClickHandler}
 				alt='lock'

--- a/src/components/Lock.tsx
+++ b/src/components/Lock.tsx
@@ -10,6 +10,7 @@ export default function Lock() {
 	const lockStatus = usePuzzleStore((state) => state.lockStatus)
 
 	if (firstRender) {
+		document.getElementById('lock')?.style.removeProperty('display')
 		setTimeout(() => {
 			usePuzzleStore.setState({ firstRender: false })
 		}, 300)

--- a/src/components/Unlocker.tsx
+++ b/src/components/Unlocker.tsx
@@ -1,90 +1,90 @@
-import React, { useEffect } from "react";
-
-export interface PropTypes {
-  secret: string;
-  addInput: (input: string) => void;
-  lockState: string;
-}
+import { useEffect } from "react";
+import { usePuzzleStore } from "../data/Store";
 
 const unlockers = ["1", "2", "3", "4"];
 const timer = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
 const animateAnswer = async (secret: string) => {
-  resetUnlockers("disabled");
-  await timer(1000);
-  // Fill the unlocker items in sequence of the secret:
-  for (const c of secret) {
-    const unlockerElement = document.getElementById("unlocker" + c);
-    if (unlockerElement) {
-      unlockerElement.className = "unlocker-item-filled";
-      await timer(1000);
-    }
-  }
-  resetUnlockers("enabled");
+	resetUnlockers("disabled");
+	await timer(1000);
+	// Fill the unlocker items in sequence of the secret:
+	for (const c of secret) {
+		const unlockerElement = document.getElementById("unlocker" + c);
+		if (unlockerElement) {
+			unlockerElement.className = "unlocker-item-filled";
+			await timer(1000);
+		}
+	}
+	resetUnlockers("enabled");
 };
 
 const resetUnlockers = (status: string) => {
-  // Un-fill the unlocker items
-  for (const c of unlockers) {
-    const unlockerElement = document.getElementById("unlocker" + c);
-    if (unlockerElement) {
-      unlockerElement.className = "unlocker-item " + status;
-    }
-  }
+	// Un-fill the unlocker items
+	for (const c of unlockers) {
+		const unlockerElement = document.getElementById("unlocker" + c);
+		if (unlockerElement) {
+			unlockerElement.className = "unlocker-item " + status;
+		}
+	}
 };
 
 const fillUnlockers = () => {
-  for (const c of unlockers) {
-    const unlockerElement = document.getElementById("unlocker" + c);
-    if (unlockerElement) {
-      unlockerElement.className = "unlocker-item-filled";
-    }
-  }
+	for (const c of unlockers) {
+		const unlockerElement = document.getElementById("unlocker" + c);
+		if (unlockerElement) {
+			unlockerElement.className = "unlocker-item-filled";
+		}
+	}
 };
 
-export default function Unlocker(props: PropTypes) {
-  useEffect(() => {
-    if (props.lockState === "open" || props.lockState === "error") {
-      fillUnlockers();
-      return;
-    }
-    animateAnswer(props.secret);
-  }, [props.secret, props.lockState]);
+export default function Unlocker() {
+	const lockStatus = usePuzzleStore((state) => state.lockStatus);
+	const secret = usePuzzleStore((state) => state.secret);
+	const input = usePuzzleStore((state) => state.input);
+	const setInput = usePuzzleStore((state) => state.setInput);
 
-  const onClickHandler = (input: string) => {
-    const unlockerElement = document.getElementById("unlocker" + input);
-    if (unlockerElement) {
-      if (
-        unlockerElement.className === "unlocker-item-filled" ||
-        unlockerElement.className === "unlocker-item disabled"
-      ) {
-        return;
-      }
-      unlockerElement.className = "unlocker-item-filled";
-      props.addInput(input);
-    }
-  };
+	useEffect(() => {
+		if (lockStatus === "open" || lockStatus === "error") {
+			fillUnlockers();
+			return;
+		}
+		animateAnswer(secret);
+	}, [secret, lockStatus]);
 
-  return (
-    <div
-      id="unlocker"
-      key={props.secret}
-      className={
-        props.lockState === "open"
-          ? "unlocker-container-exit"
-          : "unlocker-container"
-      }
-    >
-      {unlockers.map((item) => {
-        return (
-          <div
-            id={"unlocker" + item}
-            key={item}
-            className="unlocker-item disabled"
-            onClick={() => onClickHandler(item)}
-          ></div>
-        );
-      })}
-    </div>
-  );
+	const onClickHandler = (id: string) => {
+		const unlockerElement = document.getElementById("unlocker" + id);
+		if (unlockerElement) {
+			if (
+				unlockerElement.className === "unlocker-item-filled" ||
+				unlockerElement.className === "unlocker-item disabled"
+			) {
+				return;
+			}
+			unlockerElement.className = "unlocker-item-filled";
+			setInput(input + id)
+		}
+	};
+
+	return (
+		<div
+			id="unlocker"
+			key={secret}
+			className={
+				lockStatus === "open"
+					? "unlocker-container-exit"
+					: "unlocker-container"
+			}
+		>
+			{unlockers.map((item) => {
+				return (
+					<div
+						id={"unlocker" + item}
+						key={item}
+						className="unlocker-item disabled"
+						onClick={() => onClickHandler(item)}
+					></div>
+				);
+			})}
+		</div>
+	);
 }

--- a/src/components/Unlocker.tsx
+++ b/src/components/Unlocker.tsx
@@ -44,12 +44,13 @@ export default function Unlocker() {
 	const setInput = usePuzzleStore((state) => state.setInput);
 
 	useEffect(() => {
-		if (lockStatus === "open" || lockStatus === "error") {
+		if (lockStatus === 'error') {
 			fillUnlockers();
-			return;
 		}
-		animateAnswer(secret);
-	}, [secret, lockStatus]);
+		if (lockStatus === "default" && input.length < 4) {
+			animateAnswer(secret);
+		}
+	}, [secret]);
 
 	const onClickHandler = (id: string) => {
 		const unlockerElement = document.getElementById("unlocker" + id);

--- a/src/css/TabContent.css
+++ b/src/css/TabContent.css
@@ -535,6 +535,7 @@ li::marker {
 		opacity: 1;
 	}
 	100% {
+		visibility: hidden;
 		opacity: 0;
 	}
 }
@@ -558,14 +559,16 @@ li::marker {
 .contact-info {
 	width: fit-content;
 	align-self: center;
-	margin-top: 5vh;
+	margin-top: 10vh;
 	animation-name: fade-in;
+	animation-delay: 2s;
 	opacity: 0;
 	animation-duration: 1.5s;
 	animation-fill-mode: forwards;
 }
 
 .contact-info-invisible {
+	visibility: none;
 	display: none;
 }
 

--- a/src/data/Store.tsx
+++ b/src/data/Store.tsx
@@ -15,6 +15,7 @@ export interface PuzzleState {
 	setLockStatus: (lockStatus: string) => void
 	setInput: (input: string) => void
 	setIsAnimating: (isAnimating: boolean) => void
+	setFirstRender: (firstRender: boolean) => void
 }
 
 const randomizerArray = ['1', '2', '3', '4'];

--- a/src/data/Store.tsx
+++ b/src/data/Store.tsx
@@ -4,6 +4,7 @@ export interface TabState {
 	activeTab: string
 	setActiveTab: (tab: string) => void
 }
+
 export interface PuzzleState {
 	secret: string
 	input: string
@@ -27,6 +28,7 @@ export const usePuzzleStore = create<PuzzleState>((set, get) => ({
 	isAnimating: true,
 	firstRender: true,
 	resetSecret: () => set({ secret: getRandomSecret(randomizerArray) }),
+	setLockStatus: (lockStatus: string) => set({ lockStatus }),
 	setInput: (input: string) => set({ input, lockStatus: input === get().secret ? "open" : input.length === 4 ? "error" : "default" }),
 	setIsAnimating: (isAnimating: boolean) => set({ isAnimating }),
 	setFirstRender: (firstRender: boolean) => set({ firstRender }),

--- a/src/data/Store.tsx
+++ b/src/data/Store.tsx
@@ -12,9 +12,23 @@ export interface PuzzleState {
 	isAnimating: boolean
 	firstRender: boolean
 	resetSecret: () => void
+	setLockStatus: (lockStatus: string) => void
 	setInput: (input: string) => void
 	setIsAnimating: (isAnimating: boolean) => void
 }
+
+const randomizerArray = ['1', '2', '3', '4'];
+const getRandomSecret = (sourceArray: string[]) => {
+	let secret: string = '';
+	let tempArray = [...sourceArray];
+	while (tempArray.length > 0) {
+		let index = Math.floor(Math.random() * tempArray.length);
+		let randomItem = tempArray[index];
+		secret += randomItem;
+		tempArray.splice(index, 1); // Remove selected item from array
+	}
+	return secret;
+};
 
 export const useTabStore = create<TabState>((set) => ({
 	activeTab: "About Me",
@@ -33,16 +47,3 @@ export const usePuzzleStore = create<PuzzleState>((set, get) => ({
 	setIsAnimating: (isAnimating: boolean) => set({ isAnimating }),
 	setFirstRender: (firstRender: boolean) => set({ firstRender }),
 }))
-
-const randomizerArray = ['1', '2', '3', '4'];
-const getRandomSecret = (sourceArray: string[]) => {
-	let secret: string = '';
-	let tempArray = [...sourceArray];
-	while (tempArray.length > 0) {
-		let index = Math.floor(Math.random() * tempArray.length);
-		let randomItem = tempArray[index];
-		secret += randomItem;
-		tempArray.splice(index, 1); // Remove selected item from array
-	}
-	return secret;
-};

--- a/src/data/Store.tsx
+++ b/src/data/Store.tsx
@@ -4,8 +4,40 @@ export interface TabState {
 	activeTab: string
 	setActiveTab: (tab: string) => void
 }
+export interface PuzzleState {
+	secret: string
+	input: string
+	lockStatus: string
+	isAnimating: boolean
+	resetSecret: () => void
+	setInput: (input: string) => void
+	setIsAnimating: (isAnimating: boolean) => void
+}
 
 export const useTabStore = create<TabState>((set) => ({
 	activeTab: "About Me",
 	setActiveTab: (tab: string) => set({ activeTab: tab }),
 }))
+
+export const usePuzzleStore = create<PuzzleState>((set, get) => ({
+	secret: getRandomSecret(randomizerArray),
+	input: "",
+	lockStatus: "default",
+	isAnimating: true,
+	resetSecret: () => set({ secret: getRandomSecret(randomizerArray) }),
+	setInput: (input: string) => set({ input, lockStatus: input === get().secret ? "open" : input.length === 4 ? "error" : "default" }),
+	setIsAnimating: (isAnimating: boolean) => set({ isAnimating }),
+}))
+
+const randomizerArray = ['1', '2', '3', '4'];
+const getRandomSecret = (sourceArray: string[]) => {
+	let secret: string = '';
+	let tempArray = [...sourceArray];
+	while (tempArray.length > 0) {
+		let index = Math.floor(Math.random() * tempArray.length);
+		let randomItem = tempArray[index];
+		secret += randomItem;
+		tempArray.splice(index, 1); // Remove selected item from array
+	}
+	return secret;
+};

--- a/src/data/Store.tsx
+++ b/src/data/Store.tsx
@@ -9,6 +9,7 @@ export interface PuzzleState {
 	input: string
 	lockStatus: string
 	isAnimating: boolean
+	firstRender: boolean
 	resetSecret: () => void
 	setInput: (input: string) => void
 	setIsAnimating: (isAnimating: boolean) => void
@@ -24,9 +25,11 @@ export const usePuzzleStore = create<PuzzleState>((set, get) => ({
 	input: "",
 	lockStatus: "default",
 	isAnimating: true,
+	firstRender: true,
 	resetSecret: () => set({ secret: getRandomSecret(randomizerArray) }),
 	setInput: (input: string) => set({ input, lockStatus: input === get().secret ? "open" : input.length === 4 ? "error" : "default" }),
 	setIsAnimating: (isAnimating: boolean) => set({ isAnimating }),
+	setFirstRender: (firstRender: boolean) => set({ firstRender }),
 }))
 
 const randomizerArray = ['1', '2', '3', '4'];


### PR DESCRIPTION
This PR refactors components related to the lock puzzle on the "Contact" tab to prevent prop drilling by using a shared store for important puzzle state values.

## Changes
- Add PuzzleState interface and usePuzzleStore hook in Store.tsx to store puzzle state data
- Refactor Contact.tsx, Lock.tsx, Unlocker.tsx to use shared store in Store.tsx, and reduce DOM object manipulations